### PR TITLE
更改 README.md 中错误的路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 以sudo权限运行以下命令：
 
 ```bash
-./scripts/VirtualSerial.sh
+./script/VirtualSerial.sh
 ```
 
 该脚本会创建两个虚拟串口，分别是/dev/ttyUSB0和/dev/ttyUSB1。


### PR DESCRIPTION
运行第一行命令时未找到文件，发现正确的路径应为 `./script/` 而非 `./scripts/` （多了个`s`）。